### PR TITLE
Add convert-dtsv0 and dtdiff commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
 
     - name: Run to verify commands
       run: |
+        device-tree-compiler.convert-dtsv0 --version
         device-tree-compiler.dtc --version
         device-tree-compiler.fdtdump --version
         device-tree-compiler.fdtget --version

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,8 +12,14 @@ confinement: strict
 base: core18
 
 apps:
+  convert-dtsv0:
+    command: bin/convert-dtsv0
+    plugs: [ home ]
   dtc:
     command: bin/dtc
+    plugs: [ home ]
+  dtdiff:
+    command: bin/dtdiff
     plugs: [ home ]
   fdtdump:
     command: bin/fdtdump
@@ -38,14 +44,21 @@ parts:
       - libyaml-dev
       - pkg-config
     artifacts:
+      - convert-dtsv0
       - dtc
+      - dtdiff
       - fdtdump
       - fdtget
       - fdtoverlay
       - fdtput
     organize:
+      convert-dtsv0: bin/convert-dtsv0
       dtc: bin/dtc
+      dtdiff: bin/dtdiff
       fdtdump: bin/fdtdump
       fdtget: bin/fdtget
       fdtoverlay: bin/fdtoverlay
       fdtput: bin/fdtput
+    override-build: |
+      chmod +x dtdiff
+      snapcraftctl build


### PR DESCRIPTION
This commit adds the `convert-dtsv0` and `dtdiff` commands to the snap.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>